### PR TITLE
gh-1: add OrbStack Open WebUI links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A proof-backed local AI workstation for Apple Silicon: Ollama, Open WebUI, tuned helper roles, and browser-validated evidence of what actually works.
 
-Live site: [site-iota-brown-59.vercel.app](https://site-iota-brown-59.vercel.app)
+Live site: [local-llm-lab.vercel.app](https://local-llm-lab.vercel.app)
 
 GitHub repo: [Rajeev-SG/local-llm-lab](https://github.com/Rajeev-SG/local-llm-lab)
 

--- a/site/playwright.config.js
+++ b/site/playwright.config.js
@@ -1,6 +1,7 @@
 import { defineConfig, devices } from "@playwright/test";
 
-const baseURL = process.env.PLAYWRIGHT_BASE_URL || "http://127.0.0.1:4173";
+const localPreviewUrl = "http://127.0.0.1:4273";
+const baseURL = process.env.PLAYWRIGHT_BASE_URL || localPreviewUrl;
 const useLocalPreview = !process.env.PLAYWRIGHT_BASE_URL;
 
 export default defineConfig({
@@ -12,9 +13,9 @@ export default defineConfig({
   },
   webServer: useLocalPreview
     ? {
-        command: "pnpm preview --host 127.0.0.1 --port 4173",
-        url: "http://127.0.0.1:4173",
-        reuseExistingServer: true,
+        command: "pnpm preview --host 127.0.0.1 --port 4273",
+        url: localPreviewUrl,
+        reuseExistingServer: false,
         timeout: 30_000,
       }
     : undefined,

--- a/site/src/App.jsx
+++ b/site/src/App.jsx
@@ -277,6 +277,34 @@ OPENWEBUI_PASSWORD='<your-password>' ./scripts/setup-openwebui-role-models.sh`}<
                 <li>Proof notes documenting what passed and what failed</li>
                 <li>A clean landing page for sharing the project publicly</li>
               </ul>
+              <div className="local-ui-card">
+                <p className="callout-label">Open WebUI on this machine</p>
+                <div className="local-ui-actions">
+                  <a
+                    className="button button-primary"
+                    href="http://open-webui-lab.orb.local"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    Open via OrbStack
+                  </a>
+                  <a
+                    className="button button-secondary"
+                    href="http://localhost:3001"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    Use localhost fallback
+                  </a>
+                </div>
+                <p className="local-ui-note">
+                  This only works on the Mac that is actually running the lab. If
+                  the OrbStack hostname does not resolve, open OrbStack and make
+                  sure the <strong>ollama-lab</strong> and <strong>open-webui-lab</strong>
+                  containers are up, then fall back to the local port reported by
+                  <code> ./scripts/status.sh</code>.
+                </p>
+              </div>
             </div>
           </div>
         </section>

--- a/site/src/styles.css
+++ b/site/src/styles.css
@@ -382,6 +382,30 @@ img {
   padding: 1.4rem;
 }
 
+.local-ui-card {
+  margin-top: 1.4rem;
+  padding-top: 1.2rem;
+  border-top: 1px solid rgba(0, 52, 52, 0.09);
+}
+
+.local-ui-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+  margin: 0.8rem 0 1rem;
+}
+
+.local-ui-note {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.local-ui-note code {
+  font-family: "SFMono-Regular", "SFMono", ui-monospace, monospace;
+  font-size: 0.92em;
+}
+
 .callout-main {
   margin: 0.25rem 0 1rem;
   color: var(--ink);

--- a/site/tests/landing.spec.js
+++ b/site/tests/landing.spec.js
@@ -10,15 +10,13 @@ test("landing page presents the core lab story and start path", async ({ page },
 
   await page.goto("/");
 
-  await expect(
-    page.getByRole("heading", {
-      name: "Build, test, and ship a serious local LLM workstation.",
-    }),
-  ).toBeVisible();
+  await expect(page.locator("main h1")).toContainText(
+    "Build, test, and ship a serious local LLM workstation.",
+  );
 
-  await expect(
-    page.getByRole("heading", { name: "Use the model that matches the job, not the one that sounds biggest." }),
-  ).toBeVisible();
+  await expect(page.locator("#models h2")).toContainText(
+    "Use the model that matches the job, not the one that sounds biggest.",
+  );
 
   await expect(page.locator("#models").getByText("mistral-small:22b", { exact: true })).toBeVisible();
   await expect(page.locator("#models").getByText("qwen2.5-coder:14b", { exact: true })).toBeVisible();
@@ -28,6 +26,15 @@ test("landing page presents the core lab story and start path", async ({ page },
   await expect(page.locator("#start")).toBeInViewport();
 
   await expect(page.getByText("./scripts/start-ollama.sh")).toBeVisible();
+  await expect(page.getByRole("link", { name: "Open via OrbStack" })).toHaveAttribute(
+    "href",
+    "http://open-webui-lab.orb.local",
+  );
+  await expect(page.getByRole("link", { name: "Use localhost fallback" })).toHaveAttribute(
+    "href",
+    "http://localhost:3001",
+  );
+  await expect(page.getByText("This only works on the Mac that is actually running the lab.")).toBeVisible();
   expect(consoleErrors).toEqual([]);
 
   await page.waitForTimeout(500);


### PR DESCRIPTION
## Summary
- add direct Open WebUI links to the landing page
- explain the OrbStack/container dependency on the live site
- finish the Vercel cleanup under the clean local-llm-lab project name

## Validation
- pnpm build
- pnpm test:smoke
- PLAYWRIGHT_BASE_URL=https://local-llm-lab.vercel.app pnpm test:smoke

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated live site URL in README.

* **New Features**
  * Added local Open WebUI access section with OrbStack hostname and localhost port fallback options.
  * Included instructions for ensuring required containers are running.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->