### PR TITLE
gh-3: add Tailscale remote access

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,14 @@ OPENWEBUI_PASSWORD='<your-openwebui-password>' ./scripts/setup-openwebui-role-mo
 ./scripts/status.sh
 ```
 
+### 5. Enable private remote access on your own devices
+
+```bash
+./scripts/enable-tailscale-openwebui.sh
+```
+
+This does not publish Open WebUI to the open internet. It exposes the UI over Tailscale Serve so only devices signed into the same tailnet can reach it. Use this when you want your phone, tablet, or another laptop to reach the lab safely.
+
 ## Day-to-day commands
 
 ### Core services
@@ -96,6 +104,8 @@ OPENWEBUI_PASSWORD='<your-openwebui-password>' ./scripts/setup-openwebui-role-mo
 ./scripts/stop-ollama.sh
 ./scripts/start-openwebui.sh
 ./scripts/stop-openwebui.sh
+./scripts/enable-tailscale-openwebui.sh
+./scripts/disable-tailscale-openwebui.sh
 ```
 
 ### Model setup and testing
@@ -153,6 +163,16 @@ Use this lab for:
 - role-based helper design for coding agents
 - Apple Silicon model selection without guesswork
 - Open WebUI setups that need actual browser proof
+
+## Safe remote access
+
+If you want access away from the Mac without broadly exposing your laptop to the public internet, the recommended path is Tailscale Serve.
+
+- enable it with `./scripts/enable-tailscale-openwebui.sh`
+- inspect the current private URL with `./scripts/status.sh`
+- disable it with `./scripts/disable-tailscale-openwebui.sh`
+
+This gives you HTTPS access on devices signed into the same Tailscale tailnet. That is a much safer default than putting Open WebUI directly on the public internet and relying only on the app login screen.
 
 Do not use this repo as if it were a claim that all large models fit comfortably on this hardware. The value here is that the repo distinguishes clean wins from constrained experiments.
 

--- a/scripts/disable-tailscale-openwebui.sh
+++ b/scripts/disable-tailscale-openwebui.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+if ! command -v tailscale >/dev/null 2>&1; then
+  echo "tailscale is not installed."
+  exit 1
+fi
+
+tailscale serve --https=443 off >/dev/null
+
+echo "Tailscale Serve disabled for Open WebUI."

--- a/scripts/enable-tailscale-openwebui.sh
+++ b/scripts/enable-tailscale-openwebui.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib.sh"
+
+if ! command -v tailscale >/dev/null 2>&1; then
+  echo "tailscale is not installed."
+  exit 1
+fi
+
+if ! tailscale status --json >/dev/null 2>&1; then
+  echo "tailscale is not running."
+  exit 1
+fi
+
+PORT="$(preferred_openwebui_port)"
+URL="http://127.0.0.1:${PORT}"
+
+if ! curl -fsS "${URL}" >/dev/null 2>&1; then
+  echo "Open WebUI is not responding on ${URL}"
+  echo "Start it with: ${LAB_ROOT}/scripts/start-openwebui.sh"
+  exit 1
+fi
+
+tailscale serve --bg "${PORT}" >/dev/null
+
+TAILSCALE_URL="$(
+  tailscale serve status --json \
+    | jq -r '.Web | keys[0] // empty | sub(":443$"; "") | "https://" + . + "/"'
+)"
+
+echo "Tailscale Serve enabled for Open WebUI."
+echo "Private URL: ${TAILSCALE_URL}"
+echo "Only devices signed into the same tailnet can reach this URL."

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -55,6 +55,33 @@ fi
 
 echo ""
 
+# Tailscale remote access
+echo "━━━ Tailscale Remote Access ━━━"
+if command -v tailscale >/dev/null 2>&1; then
+    TS_STATE="$(tailscale status --json 2>/dev/null | jq -r '.BackendState // empty')"
+    if [[ "${TS_STATE}" == "Running" ]]; then
+        TS_URL="$(
+            tailscale serve status --json 2>/dev/null \
+                | jq -r '.Web | keys[0] // empty | sub(":443$"; "") | "https://" + . + "/"'
+        )"
+        if [[ -n "${TS_URL}" ]]; then
+            echo "Status: ✓ Private remote access enabled"
+            echo "URL: ${TS_URL}"
+            echo "Scope: Only devices signed into the same Tailscale tailnet"
+        else
+            echo "Status: ⏸ Tailscale connected, no Open WebUI serve rule"
+            echo "Enable with: ${LAB_ROOT}/scripts/enable-tailscale-openwebui.sh"
+        fi
+    else
+        echo "Status: ✗ Tailscale not connected"
+        echo "Enable with: tailscale up"
+    fi
+else
+    echo "Status: ✗ Tailscale CLI not installed"
+fi
+
+echo ""
+
 # Memory usage
 echo "━━━ System Memory ━━━"
 if command -v sysctl &> /dev/null; then
@@ -72,6 +99,7 @@ echo ""
 echo "━━━ Quick Commands ━━━"
 echo "Chat with model:    ollama run mistral-small:22b"
 echo "Open WebUI:         open ${URL}"
+echo "Private anywhere:   ${LAB_ROOT}/scripts/enable-tailscale-openwebui.sh"
 echo "Test all models:    ${LAB_ROOT}/scripts/test-models.sh"
 echo "Benchmark:          ${LAB_ROOT}/scripts/benchmark-model.sh mistral-small:22b"
 echo "Broker test sweep:  ${LAB_ROOT}/scripts/test-agent-offload.sh"

--- a/site/src/App.jsx
+++ b/site/src/App.jsx
@@ -304,6 +304,13 @@ OPENWEBUI_PASSWORD='<your-password>' ./scripts/setup-openwebui-role-models.sh`}<
                   containers are up, then fall back to the local port reported by
                   <code> ./scripts/status.sh</code>.
                 </p>
+                <p className="local-ui-note tailscale-note">
+                  For safer access on your own devices from anywhere, this lab can
+                  expose Open WebUI through private Tailscale HTTPS with
+                  <code> ./scripts/enable-tailscale-openwebui.sh</code>. That keeps
+                  the app inside your tailnet instead of publishing it openly to
+                  the internet.
+                </p>
               </div>
             </div>
           </div>

--- a/site/src/styles.css
+++ b/site/src/styles.css
@@ -401,6 +401,10 @@ img {
   line-height: 1.65;
 }
 
+.tailscale-note {
+  margin-top: 0.85rem;
+}
+
 .local-ui-note code {
   font-family: "SFMono-Regular", "SFMono", ui-monospace, monospace;
   font-size: 0.92em;

--- a/site/tests/landing.spec.js
+++ b/site/tests/landing.spec.js
@@ -35,6 +35,9 @@ test("landing page presents the core lab story and start path", async ({ page },
     "http://localhost:3001",
   );
   await expect(page.getByText("This only works on the Mac that is actually running the lab.")).toBeVisible();
+  await expect(
+    page.getByText("For safer access on your own devices from anywhere, this lab can expose Open WebUI through private Tailscale HTTPS"),
+  ).toBeVisible();
   expect(consoleErrors).toEqual([]);
 
   await page.waitForTimeout(500);


### PR DESCRIPTION
## Summary
- add private-anywhere Open WebUI access over Tailscale Serve
- document the remote-access path in the README and public site
- surface the current private Tailscale URL in the lab status output

## Validation
- bash -n scripts/enable-tailscale-openwebui.sh scripts/disable-tailscale-openwebui.sh scripts/status.sh
- ./scripts/enable-tailscale-openwebui.sh
- ./scripts/status.sh
- pnpm build
- pnpm test:smoke
- PLAYWRIGHT_BASE_URL=https://local-llm-lab.vercel.app pnpm test:smoke
- vercel deploy --cwd /Users/rajeev/Code/tools/local-llm-lab/site --yes --prod

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added private remote access for Open WebUI via Tailscale Serve, restricting access to your tailnet only
  * New commands to enable and disable Tailscale remote access
  * Status command now displays Tailscale remote access information

* **Documentation**
  * Updated guides with new "Safe remote access" section and setup instructions

* **Tests**
  * Updated landing page test to verify new remote access messaging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->