### PR TITLE
gh-5: add direct Tailscale site link

### DIFF
--- a/site/src/App.jsx
+++ b/site/src/App.jsx
@@ -296,6 +296,14 @@ OPENWEBUI_PASSWORD='<your-password>' ./scripts/setup-openwebui-role-models.sh`}<
                   >
                     Use localhost fallback
                   </a>
+                  <a
+                    className="button button-secondary"
+                    href="https://rajeevs-macbook-pro-2.tail33d641.ts.net/"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    Open via Tailscale
+                  </a>
                 </div>
                 <p className="local-ui-note">
                   This only works on the Mac that is actually running the lab. If
@@ -311,6 +319,11 @@ OPENWEBUI_PASSWORD='<your-password>' ./scripts/setup-openwebui-role-models.sh`}<
                   the app inside your tailnet instead of publishing it openly to
                   the internet.
                 </p>
+                <ol className="tailscale-steps">
+                  <li>Install Tailscale on the device you want to use remotely.</li>
+                  <li>Sign into the same Tailscale tailnet as this Mac.</li>
+                  <li>Open the Tailscale link above, then sign into Open WebUI normally.</li>
+                </ol>
               </div>
             </div>
           </div>

--- a/site/src/styles.css
+++ b/site/src/styles.css
@@ -405,6 +405,17 @@ img {
   margin-top: 0.85rem;
 }
 
+.tailscale-steps {
+  margin: 0.95rem 0 0;
+  padding-left: 1.15rem;
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.tailscale-steps li + li {
+  margin-top: 0.35rem;
+}
+
 .local-ui-note code {
   font-family: "SFMono-Regular", "SFMono", ui-monospace, monospace;
   font-size: 0.92em;

--- a/site/tests/landing.spec.js
+++ b/site/tests/landing.spec.js
@@ -34,10 +34,17 @@ test("landing page presents the core lab story and start path", async ({ page },
     "href",
     "http://localhost:3001",
   );
+  await expect(page.getByRole("link", { name: "Open via Tailscale" })).toHaveAttribute(
+    "href",
+    "https://rajeevs-macbook-pro-2.tail33d641.ts.net/",
+  );
   await expect(page.getByText("This only works on the Mac that is actually running the lab.")).toBeVisible();
   await expect(
     page.getByText("For safer access on your own devices from anywhere, this lab can expose Open WebUI through private Tailscale HTTPS"),
   ).toBeVisible();
+  await expect(page.getByText("Install Tailscale on the device you want to use remotely.")).toBeVisible();
+  await expect(page.getByText("Sign into the same Tailscale tailnet as this Mac.")).toBeVisible();
+  await expect(page.getByText("Open the Tailscale link above, then sign into Open WebUI normally.")).toBeVisible();
   expect(consoleErrors).toEqual([]);
 
   await page.waitForTimeout(500);


### PR DESCRIPTION
## Summary
- add the actual Tailscale Open WebUI URL to the production landing page
- explain how to use it from another device in the site disclaimer

## Validation
- pnpm build
- pnpm test:smoke
- PLAYWRIGHT_BASE_URL=https://local-llm-lab.vercel.app pnpm test:smoke
- vercel deploy --cwd /Users/rajeev/Code/tools/local-llm-lab/site --yes --prod